### PR TITLE
iter refresh UI

### DIFF
--- a/scripts/qualityAssurance/ui/widgets.py
+++ b/scripts/qualityAssurance/ui/widgets.py
@@ -317,6 +317,8 @@ class QualityAssuranceWidget(utils.QWidget):
                 continue
 
             widget.doFind()
+            self.repaint()
+            utils.QCoreApplication.processEvents()
 
     def doFixAll(self):
         """
@@ -328,6 +330,8 @@ class QualityAssuranceWidget(utils.QWidget):
                 continue
 
             widget.doFix()
+            self.repaint()
+            QtCore.QCoreApplication.processEvents()
 
     # ------------------------------------------------------------------------
 


### PR DESCRIPTION
![iter_refresh_UI](https://user-images.githubusercontent.com/3758308/137493165-629570ce-cc1e-4dfa-af01-c30b69e6567f.gif)
UI now updates  fix by fix, instead of freezing and then updating when all fixes are finished.
in large scenes it looks like the tool has crashed but it's just still processing and freezes maya.